### PR TITLE
Avoid server error without translation for current locale and improve ui element

### DIFF
--- a/src/Form/Type/UiElement/BlockType.php
+++ b/src/Form/Type/UiElement/BlockType.php
@@ -61,7 +61,7 @@ final class BlockType extends AbstractType
             ])
         ;
 
-        $reversedTransformer = new ReversedTransformer(new ResourceToIdentifierTransformer($this->blockRepository));
+        $reversedTransformer = new ReversedTransformer(new ResourceToIdentifierTransformer($this->blockRepository, 'code'));
         $builder->get('block')->addModelTransformer($reversedTransformer);
     }
 }

--- a/src/Form/Type/UiElement/BlockType.php
+++ b/src/Form/Type/UiElement/BlockType.php
@@ -17,6 +17,7 @@ use MonsieurBiz\SyliusCmsBlockPlugin\Repository\BlockRepository;
 use MonsieurBiz\SyliusCmsBlockPlugin\Repository\BlockRepositoryInterface;
 use Sylius\Bundle\ResourceBundle\Form\DataTransformer\ResourceToIdentifierTransformer;
 use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -28,6 +29,7 @@ final class BlockType extends AbstractType
     public function __construct(
         private BlockRepositoryInterface $blockRepository,
         private LocaleContextInterface $localeContext,
+        private TranslationLocaleProviderInterface $translationLocaleProvider,
     ) {
     }
 
@@ -49,7 +51,7 @@ final class BlockType extends AbstractType
                 'multiple' => false,
                 'choice_label' => fn (BlockInterface $block): string => \sprintf('[%s] %s', $block->getCode(), $block->getName()),
                 'query_builder' => function (BlockRepository $blockRepository) {
-                    return $blockRepository->createListQueryBuilder($this->localeContext->getLocaleCode())
+                    return $blockRepository->createListQueryBuilder($this->localeContext->getLocaleCode(), $this->translationLocaleProvider->getDefaultLocaleCode())
                         ->addOrderBy('o.code', 'ASC')
                     ;
                 },

--- a/src/Repository/BlockRepository.php
+++ b/src/Repository/BlockRepository.php
@@ -39,13 +39,34 @@ class BlockRepository extends EntityRepository implements BlockRepositoryInterfa
     /**
      * @throws NonUniqueResultException
      */
-    public function findOneEnabledByCode(string $code): ?BlockInterface
+    public function findOneEnabledByCode(string $code, ?string $locale = null, ?string $fallbackLocaleCode = null): ?BlockInterface
     {
-        /** @phpstan-ignore-next-line */
-        return $this->createQueryBuilder('b')
-            ->andWhere('b.code = :code')
-            ->andWhere('b.enabled = true')
+        $queryBuilder = $locale ? $this->createListQueryBuilder($locale, $fallbackLocaleCode) : $this->createQueryBuilder('o');
+
+        /** @var ?BlockInterface */
+        return $queryBuilder
+            ->andWhere('o.code = :code')
+            ->andWhere('o.enabled = true')
             ->setParameter('code', $code)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+
+    public function findOneEnabledByIdentifier(string $identifier, ?string $locale = null, ?string $fallbackLocaleCode = null): ?BlockInterface
+    {
+        $block = $this->findOneEnabledByCode($identifier, $locale, $fallbackLocaleCode);
+        if (null !== $block) {
+            return $block;
+        }
+
+        $queryBuilder = $locale ? $this->createListQueryBuilder($locale, $fallbackLocaleCode) : $this->createQueryBuilder('o');
+
+        /** @var ?BlockInterface */
+        return $queryBuilder
+            ->andWhere('o.id = :id')
+            ->andWhere('o.enabled = true')
+            ->setParameter('id', $identifier)
             ->getQuery()
             ->getOneOrNullResult()
         ;

--- a/src/Repository/BlockRepository.php
+++ b/src/Repository/BlockRepository.php
@@ -18,13 +18,22 @@ use Sylius\Bundle\ResourceBundle\Doctrine\ORM\EntityRepository;
 
 class BlockRepository extends EntityRepository implements BlockRepositoryInterface
 {
-    public function createListQueryBuilder(string $localeCode): QueryBuilder
+    public function createListQueryBuilder(string $localeCode, ?string $fallbackLocaleCode = null): QueryBuilder
     {
-        return $this->createQueryBuilder('o')
+        $queryBuilder = $this->createQueryBuilder('o')
             ->addSelect('translation')
             ->leftJoin('o.translations', 'translation', 'WITH', 'translation.locale = :localeCode')
             ->setParameter('localeCode', $localeCode)
         ;
+        if (null !== $fallbackLocaleCode && $fallbackLocaleCode !== $localeCode) {
+            $queryBuilder
+                ->addSelect('fallbackTranslation')
+                ->leftJoin('o.translations', 'fallbackTranslation', 'WITH', 'fallbackTranslation.locale = :fallbackLocaleCode')
+                ->setParameter('fallbackLocaleCode', $fallbackLocaleCode)
+            ;
+        }
+
+        return $queryBuilder;
     }
 
     /**

--- a/src/Repository/BlockRepositoryInterface.php
+++ b/src/Repository/BlockRepositoryInterface.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusCmsBlockPlugin\Repository;
 
+use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\QueryBuilder;
 use MonsieurBiz\SyliusCmsBlockPlugin\Entity\BlockInterface;
 use Sylius\Component\Resource\Repository\RepositoryInterface;
@@ -19,5 +20,13 @@ interface BlockRepositoryInterface extends RepositoryInterface
 {
     public function createListQueryBuilder(string $localeCode, ?string $fallbackLocaleCode = null): QueryBuilder;
 
-    public function findOneEnabledByCode(string $code): ?BlockInterface;
+    /**
+     * @throws NonUniqueResultException
+     */
+    public function findOneEnabledByCode(string $code, ?string $locale = null, ?string $fallbackLocaleCode = null): ?BlockInterface;
+
+    /**
+     * @throws NonUniqueResultException
+     */
+    public function findOneEnabledByIdentifier(string $identifier, ?string $locale = null, ?string $fallbackLocaleCode = null): ?BlockInterface;
 }

--- a/src/Repository/BlockRepositoryInterface.php
+++ b/src/Repository/BlockRepositoryInterface.php
@@ -17,7 +17,7 @@ use Sylius\Component\Resource\Repository\RepositoryInterface;
 
 interface BlockRepositoryInterface extends RepositoryInterface
 {
-    public function createListQueryBuilder(string $localeCode): QueryBuilder;
+    public function createListQueryBuilder(string $localeCode, ?string $fallbackLocaleCode = null): QueryBuilder;
 
     public function findOneEnabledByCode(string $code): ?BlockInterface;
 }

--- a/src/Resources/translations/messages.en.yaml
+++ b/src/Resources/translations/messages.en.yaml
@@ -7,6 +7,7 @@ monsieurbiz_cms_block:
     cms_content: "CMS content"
     blocks_subheader: "CMS block management"
     back_to_admin: "Back to admin"
+    block_not_found: 'Block "%name%" not found.'
     form:
       block_info: 'Block information'
       block_content: 'Block content'

--- a/src/Resources/translations/messages.fr.yaml
+++ b/src/Resources/translations/messages.fr.yaml
@@ -7,6 +7,7 @@ monsieurbiz_cms_block:
     cms_content: "Contenu CMS"
     blocks_subheader: "Gestion des blocs CMS"
     back_to_admin: "Retour à l'administration"
+    block_not_found: 'Le bloc "%name%" n''a pas été trouvé.'
     form:
       block_info: 'Informations sur le bloc'
       block_content: 'Contenu du bloc'

--- a/src/Resources/views/Admin/UiElement/block.html.twig
+++ b/src/Resources/views/Admin/UiElement/block.html.twig
@@ -10,4 +10,8 @@ element methods:
 {% set blockEntity = ui_element.getBlock(element.block) %}
 {% if blockEntity and blockEntity.enabled %}
     {{ blockEntity.content|monsieurbiz_richeditor_render_field }}
+{% else %}
+    <div class="ui orange message">
+        {{ 'monsieurbiz_cms_block.ui.block_not_found'|trans({'%name%': element.block}) }}
+    </div>
 {% endif %}

--- a/src/UiElement/BlockUiElement.php
+++ b/src/UiElement/BlockUiElement.php
@@ -11,10 +11,13 @@ declare(strict_types=1);
 
 namespace MonsieurBiz\SyliusCmsBlockPlugin\UiElement;
 
+use Doctrine\ORM\NonUniqueResultException;
 use MonsieurBiz\SyliusCmsBlockPlugin\Entity\BlockInterface;
 use MonsieurBiz\SyliusCmsBlockPlugin\Repository\BlockRepositoryInterface;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElementInterface;
 use MonsieurBiz\SyliusRichEditorPlugin\UiElement\UiElementTrait;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Resource\Translation\Provider\TranslationLocaleProviderInterface;
 
 final class BlockUiElement implements UiElementInterface
 {
@@ -22,12 +25,21 @@ final class BlockUiElement implements UiElementInterface
 
     public function __construct(
         private BlockRepositoryInterface $blockRepository,
+        private LocaleContextInterface $localeContext,
+        private TranslationLocaleProviderInterface $translationLocaleProvider,
     ) {
     }
 
-    public function getBlock(string $id): ?BlockInterface
+    public function getBlock(string $identifier): ?BlockInterface
     {
-        /** @phpstan-ignore-next-line */
-        return $this->blockRepository->find($id);
+        try {
+            return $this->blockRepository->findOneEnabledByIdentifier(
+                $identifier,
+                $this->localeContext->getLocaleCode(),
+                $this->translationLocaleProvider->getDefaultLocaleCode()
+            );
+        } catch (NonUniqueResultException) {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
## Avoid server error with a Block without translation for current locale

Example with only "fr" translation for my block:
![image](https://github.com/user-attachments/assets/ea2ad35b-1c3e-461a-8ee2-075637fc3c75)

And try to add the block for my "ES" page:

**Before**

![image](https://github.com/user-attachments/assets/afaf9f19-0fac-4e93-b5e6-21590f29fd91)

**After**

![image](https://github.com/user-attachments/assets/e6be73e6-069e-4547-aedf-c63620b770d6)


## Ui Element Block improvements

- Use block code in the ui element to make fixtures easier (is not a breaking change, because I try to find the block by code, if not, I'll search by ID)
- Use the `createListQueryBuilder` in repository to join locale (and fallback locale) to reduce the number of SQL queries
- Display a warning message in admin if the block is not found (example: if the block is deleted)

**Example with not found block**

![image](https://github.com/user-attachments/assets/7420809d-856c-4489-8fd1-2b0c117c2450)

FYI on the shop, the page is displayed and nothing is displayed for the missing block