### PR TITLE
Composer: remove strict versioning of Sylius

### DIFF
--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ['8.2', '8.3']
-                sylius: ['~2.0.0']
+                sylius: ['~2.0.0', '~2.0.1']
 
         steps:
             - name: Setup PHP

--- a/.github/workflows/recipe.yaml
+++ b/.github/workflows/recipe.yaml
@@ -17,7 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ['8.2', '8.3']
-                sylius: ['~2.0.0', '~2.0.1']
+                sylius: ['~2.0.0', '~2.1.0']
 
         steps:
             - name: Setup PHP

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,6 @@ setup_application:
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins allow-plugins true)
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins --json extra.symfony.endpoint '["https://api.github.com/repos/monsieurbiz/symfony-recipes/contents/index.json?ref=flex/master","flex://defaults"]')
 	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
-	# Temporary fix for Sylius 2.1
-	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress api-platform/state)
-	# End Temporary fix for Sylius 2.1
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini
 	(cd ${APP_DIR} && ${COMPOSER} install --no-interaction)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 SHELL=/bin/bash
 APP_DIR=tests/Application
-SYLIUS_VERSION=2.0.0
+SYLIUS_VERSION=2.1.0
 SYMFONY=cd ${APP_DIR} && symfony
 COMPOSER=symfony composer
 CONSOLE=${SYMFONY} console
@@ -74,6 +74,9 @@ setup_application:
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins allow-plugins true)
 	(cd ${APP_DIR} && ${COMPOSER} config --no-plugins --json extra.symfony.endpoint '["https://api.github.com/repos/monsieurbiz/symfony-recipes/contents/index.json?ref=flex/master","flex://defaults"]')
 	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress sylius/sylius="~${SYLIUS_VERSION}") # Make sure to install the required version of sylius because the sylius-standard has a soft constraint
+	# Temporary fix for Sylius 2.1
+	(cd ${APP_DIR} && ${COMPOSER} require --no-install --no-scripts --no-progress api-platform/state)
+	# End Temporary fix for Sylius 2.1
 	$(MAKE) ${APP_DIR}/.php-version
 	$(MAKE) ${APP_DIR}/php.ini
 	(cd ${APP_DIR} && ${COMPOSER} install --no-interaction)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | Sylius Version | PHP Version |
 |----------------|-------------|
-| 2.0, 2,1       | 8.2 - 8.3   |
+| 2.0, 2.1       | 8.2 - 8.3   |
 
 ℹ️ For Sylius 1.x, see our [1.x branch](https://github.com/monsieurbiz/SyliusCmsBlockPlugin/tree/1.x) and all 1.x releases.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 ## Compatibility
 
-| Sylius Version | PHP Version     |
-|----------------|-----------------|
-| 2.0            | 8.2 - 8.3       |
+| Sylius Version | PHP Version |
+|----------------|-------------|
+| 2.0, 2,1       | 8.2 - 8.3   |
 
 ℹ️ For Sylius 1.x, see our [1.x branch](https://github.com/monsieurbiz/SyliusCmsBlockPlugin/tree/1.x) and all 1.x releases.
 

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "monsieurbiz/sylius-rich-editor-plugin": "^3.0",
         "php": "^8.2",
-        "sylius/sylius": "~2.0.0"
+        "sylius/sylius": "~2.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",

--- a/dist/src/Context/Channel/RequestBased/HostnameAndPortBasedRequestResolver.php
+++ b/dist/src/Context/Channel/RequestBased/HostnameAndPortBasedRequestResolver.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of Monsieur Biz's Sylius Cms Block Plugin for Sylius.
+ * (c) Monsieur Biz <sylius@monsieurbiz.com>
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App\Context\Channel\RequestBased;
+
+use Sylius\Component\Channel\Context\RequestBased\RequestResolverInterface;
+use Sylius\Component\Channel\Model\ChannelInterface;
+use Sylius\Component\Channel\Repository\ChannelRepositoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\AutoconfigureTag;
+use Symfony\Component\HttpFoundation\Request;
+
+#[AutoconfigureTag('sylius.context.channel.request_based.resolver')]
+final class HostnameAndPortBasedRequestResolver implements RequestResolverInterface
+{
+    public function __construct(private ChannelRepositoryInterface $channelRepository)
+    {
+    }
+
+    public function findChannel(Request $request): ?ChannelInterface
+    {
+        return $this->channelRepository->findOneEnabledByHostname($request->getHost() . ':' . $request->getPort());
+    }
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,5 @@ parameters:
         - 'tests/Application/**/*'
 
     ignoreErrors:
+        - identifier: missingType.generics
         - identifier: missingType.iterableValue


### PR DESCRIPTION
Allow installation of the plugin with version 2.1 of Sylius.

I think this change might ease the process of maintenance in the future.